### PR TITLE
fixed incorrect description of type arg in metaphor.search

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This function performs a search on the Metaphor API.
   - `start_published_date` (str): The start date for when the document was published (in YYYY-MM-DD format).
   - `end_published_date` (str): The end date for when the document was published (in YYYY-MM-DD format).
   - `use_autoprompt` (bool): Whether to use autoprompt for the search.
-  - `type` (str): The type of document to search for.
+  - `type` (str): The type of search, 'keyword' or 'neural'. Default: neural
 
 #### Returns
 `SearchResponse`: A dataclass containing the search results.


### PR DESCRIPTION
The description of the type keyword currently is wrong. 

This should also be referenced somewhere in the source code so the LLM-based support bot can address keyword search related questions - currently it doesn't do so well here: https://chat.openai.com/share/3b3a60a3-b15b-4158-bd13-758efe26a1cb 